### PR TITLE
Upgraded google http client

### DIFF
--- a/mailosaur-java.iml
+++ b/mailosaur-java.iml
@@ -5,21 +5,21 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.9.0-beta" level="project" />
+    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.18.0-rc" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.guava:guava:11.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.0.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.0.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.0.1" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.1.1" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.4" level="project" />
-    <orderEntry type="library" name="Maven: xpp3:xpp3:1.1.4c" level="project" />
-    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java:2.2.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-gson:1.18.0-rc" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>
 </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,59 +1,71 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.mailosaur</groupId>
-  <artifactId>mailosaur-java</artifactId>
-  <version>1.0.7-SNAPSHOT</version>
-  <packaging>jar</packaging>
+	<groupId>com.mailosaur</groupId>
+	<artifactId>mailosaur-java</artifactId>
+	<version>1.0.7-SNAPSHOT</version>
+	<packaging>jar</packaging>
 
-  <name>mailosaur-java</name>
-  <url>https://github.com/mailosaurapp/mailosaur-java</url>
-  <description>Mailosaur Java Bindings for Email Test Automation</description>
+	<name>mailosaur-java</name>
+	<url>https://github.com/mailosaurapp/mailosaur-java</url>
+	<description>Mailosaur Java Bindings for Email Test Automation</description>
 
-  <organization>
-  	<name>Clickity Ltd</name>
-  	<url>https://mailosaur.com</url>
-  </organization>
+	<organization>
+		<name>Clickity Ltd</name>
+		<url>https://mailosaur.com</url>
+	</organization>
 
-  <scm>
-        <connection>scm:git:git@github.com:mailosaur/mailosaur-java.git</connection>
-        <developerConnection>scm:git:git@github.com:mailosaurapp/mailosaur-java.git</developerConnection>
-        <url>git@github.com:mailosaurapp/mailosaur-java.git</url>
-    </scm>
-    
-  <licenses>
-    <license>
-      <name>MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-    </license>
-  </licenses>
-  
-  <developers>
-  	<developer>
-      <id>clickity</id>
-      <name>Clickity</name>
-      <organization>Clickity Ltd</organization>
-      <organizationUrl>https://mailosaur.com</organizationUrl>
-      <timezone>0</timezone>
-    </developer>
-  </developers>
+	<scm>
+		<connection>scm:git:git@github.com:mailosaur/mailosaur-java.git</connection>
+		<developerConnection>scm:git:git@github.com:mailosaurapp/mailosaur-java.git</developerConnection>
+		<url>git@github.com:mailosaurapp/mailosaur-java.git</url>
+	</scm>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+	<licenses>
+		<license>
+			<name>MIT license</name>
+			<url>http://www.opensource.org/licenses/mit-license.php</url>
+		</license>
+	</licenses>
 
-  <dependencies>
-    <dependency>
-    	<groupId>com.google.http-client</groupId>
-    	<artifactId>google-http-client</artifactId>
-    	<version>1.9.0-beta</version>
-    </dependency>
-  </dependencies>
-  
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-    
+	<developers>
+		<developer>
+			<id>clickity</id>
+			<name>Clickity</name>
+			<organization>Clickity Ltd</organization>
+			<organizationUrl>https://mailosaur.com</organizationUrl>
+			<timezone>0</timezone>
+		</developer>
+	</developers>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client</artifactId>
+			<version>1.18.0-rc</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client-gson</artifactId>
+			<version>1.18.0-rc</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+
 </project>

--- a/src/main/java/com/mailosaur/MailboxApi.java
+++ b/src/main/java/com/mailosaur/MailboxApi.java
@@ -1,7 +1,5 @@
 package com.mailosaur;
 
-import com.mailosaur.model.*;
-
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -20,73 +18,75 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.http.json.JsonHttpParser;
 import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.mailosaur.model.DeleteResult;
+import com.mailosaur.model.Email;
 
 public final class MailboxApi {
-	
-	 static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
-	 static final JsonFactory JSON_FACTORY = new GsonFactory();
-	 	 
-	 static final HttpRequestFactory requestFactory =
-		        HTTP_TRANSPORT.createRequestFactory(new HttpRequestInitializer() {
-			          public void initialize(HttpRequest request) {
-			        	request.addParser(new JsonHttpParser(JSON_FACTORY));
-			          }
-			        });
+
+	static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+	static final JsonFactory JSON_FACTORY = new GsonFactory();
+
+	static final HttpRequestFactory requestFactory =
+			HTTP_TRANSPORT.createRequestFactory(new HttpRequestInitializer() {
+				public void initialize(HttpRequest request) {
+					request.setParser(new JsonObjectParser(JSON_FACTORY));
+				}
+			});
 
 	final String BASE_URI = "https://api.mailosaur.com/v2";
 	final String MAILBOX;
 	final String API_KEY;
-	
+
 	public MailboxApi(String mailbox, String apiKey) {
 		MAILBOX = mailbox;
 		API_KEY = apiKey;
 	}
-	
+
 	void writeByteArrayToFile(final byte[] fileBytes, final String filePath) throws com.mailosaur.exception.MailosaurException {
 		FileOutputStream stream = null;
 		try {
-			stream = new FileOutputStream(filePath);			
+			stream = new FileOutputStream(filePath);
 		} catch (FileNotFoundException e) {
 			throw new com.mailosaur.exception.MailosaurException("Unable to write to file: File not found " + filePath, e);
 		} finally {
-		    try {
-		    	stream.write(fileBytes);
+			try {
+				stream.write(fileBytes);
 				stream.close();
 			} catch (IOException e) {
 				throw new com.mailosaur.exception.MailosaurException("Unable to write to file", e);
 			}
 		}
 	}
-	
+
 	String buildQueryString(final Map<String, String> map) throws UnsupportedEncodingException {
 		Map<String, String> queryParams = new HashMap<String, String>();
 		queryParams.put("key", API_KEY);
 		queryParams.putAll(map);
-		
+
 		StringBuilder sb = new StringBuilder();
-		  for(Entry<String, String> entry : queryParams.entrySet()){
-		      if(sb.length() > 0){
-		          sb.append('&');
-		      }
-		      
-		      sb.append(URLEncoder.encode(entry.getKey(), "UTF-8"))
-		      	.append('=')
-		      	.append(URLEncoder.encode(entry.getValue(), "UTF-8"));
-		  }
-		  return sb.toString();
+		for (Entry<String, String> entry : queryParams.entrySet()) {
+			if (sb.length() > 0) {
+				sb.append('&');
+			}
+
+			sb.append(URLEncoder.encode(entry.getKey(), "UTF-8"))
+					.append('=')
+					.append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+		}
+		return sb.toString();
 	}
-	
+
 	GenericUrl buildUrl(final String path, Map<String, String> queryParams) throws UnsupportedEncodingException {
 		return new GenericUrl(BASE_URI + path + "?" + buildQueryString(queryParams));
 	}
-	
+
 	HttpRequest buildRequest(String method, String path) throws com.mailosaur.exception.MailosaurException {
 		return buildRequest(method, path, null);
 	}
-	
+
 	HttpRequest buildRequest(String method, String path, Map<String, String> queryParams) throws com.mailosaur.exception.MailosaurException {
 		try {
 			GenericUrl url = buildUrl(path, queryParams);
@@ -99,7 +99,7 @@ public final class MailboxApi {
 			throw new com.mailosaur.exception.MailosaurException("Unable to build web request", e);
 		}
 	}
-	
+
 	ByteArrayOutputStream downloadFileAsStream(String method, String urlStr) throws com.mailosaur.exception.MailosaurException {
 		HttpRequest request = buildRequest(method, urlStr);
 		try {
@@ -110,7 +110,7 @@ public final class MailboxApi {
 			throw new com.mailosaur.exception.MailosaurException("Unable to download file", e);
 		}
 	}
-	
+
 	String buildUrlPath(String... args) throws com.mailosaur.exception.MailosaurException {
 		StringBuilder sb = new StringBuilder();
 		for (String arg : args) {
@@ -119,10 +119,10 @@ public final class MailboxApi {
 			} catch (UnsupportedEncodingException e) {
 				throw new com.mailosaur.exception.MailosaurException("Unable to encode URL", e);
 			}
-	    }
+		}
 		return sb.toString();
 	}
-	
+
 	Email[] getEmails(Map<String, String> searchCriteria) throws com.mailosaur.exception.MailosaurException {
 		try {
 			HashMap<String, String> queryParams = new HashMap<String, String>();
@@ -135,49 +135,49 @@ public final class MailboxApi {
 		}
 	}
 
-    OutputStream getAttachmentAsStream(String attachmentId) throws com.mailosaur.exception.MailosaurException {
-        return downloadFileAsStream("GET", buildUrlPath("attachment", attachmentId));
-    }
+	OutputStream getAttachmentAsStream(String attachmentId) throws com.mailosaur.exception.MailosaurException {
+		return downloadFileAsStream("GET", buildUrlPath("attachment", attachmentId));
+	}
 
-    void saveAttachmentToFile(String attachmentId, String filePath) throws com.mailosaur.exception.MailosaurException {
-        byte[] fileBytes = getAttachment(attachmentId);
-        writeByteArrayToFile(fileBytes, filePath);
-    }
+	void saveAttachmentToFile(String attachmentId, String filePath) throws com.mailosaur.exception.MailosaurException {
+		byte[] fileBytes = getAttachment(attachmentId);
+		writeByteArrayToFile(fileBytes, filePath);
+	}
 
-    OutputStream getRawEmailAsStream(String rawId) throws com.mailosaur.exception.MailosaurException {
-        return downloadFileAsStream("GET", buildUrlPath("raw", rawId));
-    }
+	OutputStream getRawEmailAsStream(String rawId) throws com.mailosaur.exception.MailosaurException {
+		return downloadFileAsStream("GET", buildUrlPath("raw", rawId));
+	}
 
-    void saveRawEmailToFile(String rawId, String filePath) throws com.mailosaur.exception.MailosaurException {
-        byte[] fileBytes = getRawEmail(rawId);
-        writeByteArrayToFile(fileBytes, filePath);
-    }
+	void saveRawEmailToFile(String rawId, String filePath) throws com.mailosaur.exception.MailosaurException {
+		byte[] fileBytes = getRawEmail(rawId);
+		writeByteArrayToFile(fileBytes, filePath);
+	}
 
-    public Email[] getEmails() throws com.mailosaur.exception.MailosaurException {
+	public Email[] getEmails() throws com.mailosaur.exception.MailosaurException {
 		return getEmails(new HashMap<String, String>());
 	}
-		
+
 	public Email[] getEmails(String searchPattern) throws com.mailosaur.exception.MailosaurException {
 		HashMap<String, String> searchCriteria = new HashMap<String, String>();
 		searchCriteria.put("search", searchPattern);
 		return getEmails(searchCriteria);
 	}
-	
+
 	public Email[] getEmailsByRecipient(String recipientEmail) throws com.mailosaur.exception.MailosaurException {
 		HashMap<String, String> searchCriteria = new HashMap<String, String>();
 		searchCriteria.put("recipient", recipientEmail);
 		return getEmails(searchCriteria);
 	}
-	
+
 	public Email getEmail(String emailId) throws com.mailosaur.exception.MailosaurException {
 		try {
-			HttpRequest request = buildRequest("GET",  buildUrlPath("email", emailId));
+			HttpRequest request = buildRequest("GET", buildUrlPath("email", emailId));
 			return request.execute().parseAs(Email.class);
 		} catch (IOException e) {
 			throw new com.mailosaur.exception.MailosaurException("Unable to parse API response", e);
 		}
 	}
-	
+
 	public Boolean deleteAllEmail() throws com.mailosaur.exception.MailosaurException {
 		try {
 			HashMap<String, String> queryParams = new HashMap<String, String>();
@@ -189,7 +189,7 @@ public final class MailboxApi {
 			throw new com.mailosaur.exception.MailosaurException("Unable to parse API response", e);
 		}
 	}
-	
+
 	public Boolean deleteEmail(String emailId) throws com.mailosaur.exception.MailosaurException {
 		try {
 			HttpRequest request = buildRequest("POST", buildUrlPath("email", emailId, "delete"));


### PR DESCRIPTION
Sorry about the formatting.  This pull request upgrades the google-http-client from 1.0.9-beta to 1.18.0-rc.  The old client library isn't compatible with the later apache httpclient and google guava libs, so it's almost unusable for me without being upgraded.

I had a crack at sorting out your tests, but they seem to reference json files that I don't have (and it looks like they were written in .NET).

Cheers,

Ben.
