### PR TITLE
Intellisense: doc comments and inbox (server) terminology

### DIFF
--- a/src/main/java/com/mailosaur/Analysis.java
+++ b/src/main/java/com/mailosaur/Analysis.java
@@ -6,7 +6,8 @@ import com.mailosaur.models.SpamAnalysisResult;
 import com.mailosaur.models.DeliverabilityReport;
 
 /**
- * Message analysis operations.
+ * Operations for analyzing the content and deliverability of an email, including SpamAssassin
+ * scoring and per-provider deliverability reports. Accessed via {@link MailosaurClient#analysis()}.
  */
 public class Analysis {
     private MailosaurClient client;

--- a/src/main/java/com/mailosaur/Devices.java
+++ b/src/main/java/com/mailosaur/Devices.java
@@ -8,6 +8,11 @@ import com.mailosaur.models.OtpResult;
 import java.io.IOException;
 import java.util.HashMap;
 
+/**
+ * Operations for managing virtual security devices and retrieving their current one-time
+ * passwords (OTPs), used to automate testing of app-based multi-factor authentication.
+ * Accessed via {@link MailosaurClient#devices()}.
+ */
 public class Devices {
     private MailosaurClient client;
 
@@ -39,12 +44,13 @@ public class Devices {
     }
 
     /**
-     * Retrieve the current one-time password.
+     * Retrieves the current one-time password for a saved device, or given a base32-encoded
+     * shared secret.
      *
      * @param query Either the unique identifier of the device, or a base32-encoded shared secret.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
-     * @return The current one-time password.
+     * @return An {@link OtpResult} containing the current one-time password.
      */
     public OtpResult otp(String query) throws IOException, MailosaurException {
         if (query.contains("-")) {

--- a/src/main/java/com/mailosaur/Files.java
+++ b/src/main/java/com/mailosaur/Files.java
@@ -10,7 +10,9 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * File operations.
+ * Operations for downloading the raw content associated with a message &mdash; file attachments,
+ * the full EML source of an email, and rendered email previews. Accessed via
+ * {@link MailosaurClient#files()}.
  */
 public class Files {
     private MailosaurClient client;
@@ -48,9 +50,10 @@ public class Files {
      * the unique identifier for the required preview.
      *
      * @param previewId The identifier of the email preview to be downloaded.
-     * @throws MailosaurException Thrown if Mailosaur responds with an error.
+     * @throws MailosaurException With error code {@code preview_timeout} if the preview is not
+     *     generated within the time limit.
      * @throws IOException Unexpected exception.
-     * @return The byte array if successful.
+     * @return A byte array containing the preview screenshot image.
      */
     public byte[] getPreview(String previewId) throws MailosaurException, IOException {
         int timeout = 120000;

--- a/src/main/java/com/mailosaur/MailosaurClient.java
+++ b/src/main/java/com/mailosaur/MailosaurClient.java
@@ -19,6 +19,13 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mailosaur.models.MessageSummary;
 
+/**
+ * The Mailosaur client &mdash; the main entry point to the Mailosaur API. Construct an instance
+ * with your API key (or set the {@code MAILOSAUR_API_KEY} environment variable), then use the
+ * operations namespaces ({@link #messages()}, {@link #servers()}, {@link #files()},
+ * {@link #devices()}, {@link #analysis()}, {@link #previews()}, {@link #usage()}) to automate
+ * email and SMS testing.
+ */
 public class MailosaurClient {
     final String VERSION = "9.0.0";
 	final String API_KEY;
@@ -82,91 +89,98 @@ public class MailosaurClient {
 	}
 	
 	/**
-     * Message analysis operations
+     * Operations for analyzing email content and deliverability, including spam scoring.
      */
     private Analysis analysis;
 
     /**
-     * Gets message analysis operations.
-     * @return Message analysis operations.
+     * Gets the operations for analyzing email content and deliverability, including spam scoring.
+     *
+     * @return The {@link Analysis} operations namespace.
      */
     public Analysis analysis() {
         return this.analysis;
     }
 
     /**
-     * File operations
+     * Operations for downloading attachments, EML source, and email preview screenshots.
      */
     private Files files;
 
     /**
-     * Gets file operations.
-     * @return File operations.
+     * Gets the operations for downloading attachments, EML source, and email preview screenshots.
+     *
+     * @return The {@link Files} operations namespace.
      */
     public Files files() {
         return this.files;
     }
 
     /**
-     * Message operations
+     * Operations for finding, retrieving, creating, and managing email and SMS messages.
      */
     private Messages messages;
 
     /**
-     * Gets message operations.
-     * @return Message operations.
+     * Gets the operations for finding, retrieving, creating, and managing email and SMS messages.
+     *
+     * @return The {@link Messages} operations namespace.
      */
     public Messages messages() {
         return this.messages;
     }
 
     /**
-     * Server management operations
+     * Operations for creating and managing your Mailosaur servers (virtual inboxes).
      */
     private Servers servers;
 
     /**
-     * Gets server management operations.
-     * @return Server management operations.
+     * Gets the operations for creating and managing your Mailosaur servers (virtual inboxes).
+     *
+     * @return The {@link Servers} operations namespace.
      */
     public Servers servers() {
         return this.servers;
     }
 
     /**
-     * Account usage operations
+     * Operations for inspecting account usage limits and recent transactional usage.
      */
     private Usage usage;
 
     /**
-     * Gets account usage operations.
-     * @return Account usage operations.
+     * Gets the operations for inspecting account usage limits and recent transactional usage.
+     *
+     * @return The {@link Usage} operations namespace.
      */
     public Usage usage() {
         return this.usage;
     }
 
     /**
-     * Device management operations
+     * Operations for managing virtual security devices and retrieving their one-time passwords.
      */
     private Devices devices;
 
     /**
-     * Gets device management operations.
-     * @return Device management operations.
+     * Gets the operations for managing virtual security devices and retrieving their one-time passwords.
+     *
+     * @return The {@link Devices} operations namespace.
      */
     public Devices devices() {
         return this.devices;
     }
 
     /**
-     * Email Previews operations
+     * Operations for discovering the email clients available for generating email previews.
      */
     private Previews previews;
 
     /**
-     * Gets Email Previews operations.
-     * @return Email Previews operations.
+     * Gets the operations for discovering the email clients available for generating email previews.
+     *
+     * @return The {@link Previews} operations namespace.
      */
     public Previews previews() {
         return this.previews;

--- a/src/main/java/com/mailosaur/MailosaurClient.java
+++ b/src/main/java/com/mailosaur/MailosaurClient.java
@@ -131,12 +131,12 @@ public class MailosaurClient {
     }
 
     /**
-     * Operations for creating and managing your Mailosaur servers (virtual inboxes).
+     * Operations for creating and managing your Mailosaur inboxes (servers).
      */
     private Servers servers;
 
     /**
-     * Gets the operations for creating and managing your Mailosaur servers (virtual inboxes).
+     * Gets the operations for creating and managing your Mailosaur inboxes (servers).
      *
      * @return The {@link Servers} operations namespace.
      */

--- a/src/main/java/com/mailosaur/Messages.java
+++ b/src/main/java/com/mailosaur/Messages.java
@@ -14,7 +14,7 @@ import com.mailosaur.models.*;
 
 /**
  * Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
- * email and SMS messages received by your Mailosaur servers. Accessed via
+ * email and SMS messages received by your Mailosaur inboxes (servers). Accessed via
  * {@link MailosaurClient#messages()}.
  */
 public class Messages {
@@ -64,7 +64,7 @@ public class Messages {
      * Retrieve a message using search criteria.
      * Returns as soon as an message matching the specified search criteria is found.
      *
-     * @param server The identifier of the server hosting the message.
+     * @param server The identifier of the inbox (server) hosting the message.
      * @param criteria The search criteria to use in order to find a match.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
@@ -83,7 +83,7 @@ public class Messages {
      * Retrieve a message using search criteria.
      * Returns as soon as an message matching the specified search criteria is found.
      *
-     * @param server The identifier of the server hosting the message.
+     * @param server The identifier of the inbox (server) hosting the message.
      * @param criteria The search criteria to use in order to find a match.
      * @param timeout Specify how long to wait for a matching result (in milliseconds).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
@@ -104,7 +104,7 @@ public class Messages {
      * Retrieve a message using search criteria.
      * Returns as soon as an message matching the specified search criteria is found.
      *
-     * @param server The identifier of the server hosting the message.
+     * @param server The identifier of the inbox (server) hosting the message.
      * @param criteria The search criteria to use in order to find a match.
      * @param receivedAfter Limits results to only messages received after this timestamp.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
@@ -125,7 +125,7 @@ public class Messages {
      * Retrieve a message using search criteria.
      * Returns as soon as an message matching the specified search criteria is found.
      *
-     * @param server The identifier of the server hosting the message.
+     * @param server The identifier of the inbox (server) hosting the message.
      * @param criteria The search criteria to use in order to find a match.
      * @param timeout Specify how long to wait for a matching result (in milliseconds).
      * @param receivedAfter Limits results to only messages received after this timestamp.
@@ -171,9 +171,9 @@ public class Messages {
     
     /**
      * Delete all messages.
-     * Permanently deletes all messages held by the specified server. This operation cannot be undone. Also deletes any attachments related to each message.
+     * Permanently deletes all messages held by the specified inbox (server). This operation cannot be undone. Also deletes any attachments related to each message.
      *
-     * @param server The identifier of the server to be emptied.
+     * @param server The identifier of the inbox (server) to be emptied.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      */
     public void deleteAll(String server) throws MailosaurException {
@@ -208,7 +208,7 @@ public class Messages {
      * List all messages.
      * Returns a list of your messages. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
      * @return the MessageListResult object if successful.
@@ -226,7 +226,7 @@ public class Messages {
      * List all messages.
      * Returns a list of your messages. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param receivedAfter Limits results to only messages received after this timestamp.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
@@ -246,7 +246,7 @@ public class Messages {
      * List all messages.
      * Returns a list of your messages. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param page Used in conjunction with `itemsPerPage` to support pagination.
      * @param itemsPerPage A limit on the number of results to be returned per page. Can be set between 1 and 1000 items, the default is 50.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
@@ -268,7 +268,7 @@ public class Messages {
      * List all messages.
      * Returns a list of your messages. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param page Used in conjunction with `itemsPerPage` to support pagination.
      * @param itemsPerPage A limit on the number of results to be returned per page. Can be set between 1 and 1000 items, the default is 50.
      * @param receivedAfter Limits results to only messages received after this timestamp.
@@ -360,7 +360,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
@@ -380,7 +380,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param page Used in conjunction with `itemsPerPage` to support pagination.
      * @param itemsPerPage A limit on the number of results to be returned per page. Can be set between 1 and 1000 items, the default is 50.
@@ -404,7 +404,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param timeout Specify how long to wait for a matching result (in milliseconds).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
@@ -426,7 +426,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param timeout Specify how long to wait for a matching result (in milliseconds).
      * @param errorOnTimeout When set to false, an error will not be throw if timeout is reached (default: true).
@@ -449,7 +449,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param receivedAfter Limits results to only messages received after this timestamp.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
@@ -471,7 +471,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param timeout Specify how long to wait for a matching result (in milliseconds).
      * @param receivedAfter Limits results to only messages received after this timestamp.
@@ -495,7 +495,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param timeout Specify how long to wait for a matching result (in milliseconds).
      * @param errorOnTimeout When set to false, an error will not be throw if timeout is reached (default: true).
@@ -520,7 +520,7 @@ public class Messages {
      * Search for messages.
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @param criteria The search criteria to match results against.
      * @param page Used in conjunction with `itemsPerPage` to support pagination.
      * @param itemsPerPage A limit on the number of results to be returned per page. Can be set between 1 and 1000 items, the default is 50.
@@ -551,7 +551,7 @@ public class Messages {
      * useful in scenarios where you want an email to trigger a workflow in your
      * product.
      *
-     * @param server The identifier of the server to create the message in.
+     * @param server The identifier of the inbox (server) to create the message in.
      * @param messageCreateOptions The options with which to create the message.
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.

--- a/src/main/java/com/mailosaur/Messages.java
+++ b/src/main/java/com/mailosaur/Messages.java
@@ -13,8 +13,9 @@ import com.google.gson.JsonSerializer;
 import com.mailosaur.models.*;
 
 /**
- * An instance of this class provides access to all the operations defined
- * in Messages.
+ * Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
+ * email and SMS messages received by your Mailosaur servers. Accessed via
+ * {@link MailosaurClient#messages()}.
  */
 public class Messages {
 	/** The service client containing this operation class. */
@@ -30,14 +31,16 @@ public class Messages {
     }
 
     /**
-     * Retrieve a message using search criteria.
-     * Returns as soon as an message matching the specified search criteria is found.
+     * Waits for a message to be found. Returns as soon as a message matching the specified
+     * search criteria is found. This is the most efficient method of looking up a message,
+     * therefore we recommend using it wherever possible.
      *
      * @param params Message searching parameters.
-     * @param criteria The search criteria to match results against.
-     * @throws MailosaurException Thrown if Mailosaur responds with an error.
+     * @param criteria The criteria with which to find messages during a search.
+     * @throws MailosaurException With error code {@code no_messages_found} if no matching message
+     *     exists, or {@code search_timeout} if no matching message arrives before the timeout elapses.
      * @throws IOException Unexpected exception.
-     * @return the Message object if successful.
+     * @return The first {@link Message} matching the criteria.
      */
     public Message get(MessageSearchParams params, SearchCriteria criteria) throws IOException, MailosaurException {
         // Timeout defaulted to 10s, receivedAfter to 1h
@@ -290,10 +293,11 @@ public class Messages {
      * Returns a list of messages matching the specified search criteria. The messages are returned sorted by received date, with the most recently-received messages appearing first.
      *
      * @param params Message searching parameters.
-     * @param criteria The search criteria to match results against.
-     * @throws MailosaurException Thrown if Mailosaur responds with an error.
+     * @param criteria The criteria with which to find messages during a search.
+     * @throws MailosaurException With error code {@code search_timeout} if no matching message is
+     *     found before the timeout elapses, unless {@code errorOnTimeout} is set to false.
      * @throws IOException Unexpected exception.
-     * @return the MessageListResult object if successful.
+     * @return A {@link MessageListResult} containing the matching message summaries.
      */
     public MessageListResult search(MessageSearchParams params, SearchCriteria criteria) throws IOException, MailosaurException {
         HashMap<String, String> query = new HashMap<String, String>();

--- a/src/main/java/com/mailosaur/Previews.java
+++ b/src/main/java/com/mailosaur/Previews.java
@@ -4,6 +4,11 @@ import com.mailosaur.models.EmailClientListResult;
 
 import java.io.IOException;
 
+/**
+ * Operations for discovering the email clients available for generating email previews
+ * (screenshots of an email rendered in real clients). Accessed via
+ * {@link MailosaurClient#previews()}.
+ */
 public class Previews {
     private MailosaurClient client;
 

--- a/src/main/java/com/mailosaur/Servers.java
+++ b/src/main/java/com/mailosaur/Servers.java
@@ -9,6 +9,11 @@ import com.mailosaur.models.Server;
 import com.mailosaur.models.ServerCreateOptions;
 import com.mailosaur.models.ServerListResult;
 
+/**
+ * Operations for creating and managing your Mailosaur servers &mdash; the virtual inboxes that
+ * group your tests together, each with its own domain and SMTP/POP3/IMAP credentials. Accessed
+ * via {@link MailosaurClient#servers()}.
+ */
 public class Servers {
     private MailosaurClient client;
     

--- a/src/main/java/com/mailosaur/Servers.java
+++ b/src/main/java/com/mailosaur/Servers.java
@@ -10,7 +10,7 @@ import com.mailosaur.models.ServerCreateOptions;
 import com.mailosaur.models.ServerListResult;
 
 /**
- * Operations for creating and managing your Mailosaur servers &mdash; the virtual inboxes that
+ * Operations for creating and managing your Mailosaur inboxes (servers) &mdash; they
  * group your tests together, each with its own domain and SMTP/POP3/IMAP credentials. Accessed
  * via {@link MailosaurClient#servers()}.
  */
@@ -22,47 +22,47 @@ public class Servers {
     }
 
     /**
-     * Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.
+     * Returns a list of your inboxes (servers). Inboxes (servers) are returned sorted in alphabetical order.
      *
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
-     * @return The result of the server listing operation.
+     * @return The result of the inbox (server) listing operation.
      */
     public ServerListResult list() throws IOException, MailosaurException {
         return client.request("GET", "api/servers").parseAs(ServerListResult.class);
     }
 
     /**
-     * Creates a new virtual server.
+     * Creates a new inbox (server).
      *
-     * @param options Options used to create a new Mailosaur server.
+     * @param options Options used to create a new Mailosaur inbox (server).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
-     * @return Mailosaur virtual SMTP/SMS server.
+     * @return A Mailosaur inbox (server) &mdash; a virtual SMTP/SMS endpoint.
      */
     public Server create(ServerCreateOptions options) throws IOException, MailosaurException {
     	return client.request("POST", "api/servers", options).parseAs(Server.class);
     }
 
     /**
-     * Retrieves the detail for a single server.
+     * Retrieves the detail for a single inbox (server).
      *
-     * @param serverId The unique identifier of the server.
+     * @param serverId The unique identifier of the inbox (server).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
-     * @return Mailosaur virtual SMTP/SMS server.
+     * @return A Mailosaur inbox (server) &mdash; a virtual SMTP/SMS endpoint.
      */
     public Server get(String serverId) throws IOException, MailosaurException {
     	return client.request("GET", "api/servers/" + serverId).parseAs(Server.class);
     }
 
     /**
-     * Retrieves the password for a server. This password can be used for SMTP, POP3, and IMAP connectivity.
+     * Retrieves the password for an inbox (server). This password can be used for SMTP, POP3, and IMAP connectivity.
      *
-     * @param serverId The unique identifier of the server.
+     * @param serverId The unique identifier of the inbox (server).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
-     * @return The password for the server.
+     * @return The password for the inbox (server).
      */
     public String getPassword(String serverId) throws IOException, MailosaurException {
     	GenericJson json = client.request("GET", "api/servers/" + serverId + "/password").parseAs(GenericJson.class);
@@ -70,22 +70,22 @@ public class Servers {
     }
 
     /**
-     * Updates the attributes of a server.
+     * Updates the attributes of an inbox (server).
      *
-     * @param serverId The unique identifier of the server.
-     * @param server The updated server.
+     * @param serverId The unique identifier of the inbox (server).
+     * @param server The updated inbox (server).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      * @throws IOException Unexpected exception.
-     * @return Mailosaur virtual SMTP/SMS server.
+     * @return A Mailosaur inbox (server) &mdash; a virtual SMTP/SMS endpoint.
      */
     public Server update(String serverId, Server server) throws IOException, MailosaurException {
     	return client.request("PUT", "api/servers/" + serverId, server).parseAs(Server.class);
     }
 
     /**
-     * Permanently delete a server. This will also delete all messages, associated attachments, etc. within the server. This operation cannot be undone.
+     * Permanently delete an inbox (server). This will also delete all messages, associated attachments, etc. within the inbox (server). This operation cannot be undone.
      *
-     * @param serverId The unique identifier of the server.
+     * @param serverId The unique identifier of the inbox (server).
      * @throws MailosaurException Thrown if Mailosaur responds with an error.
      */
     public void delete(String serverId) throws MailosaurException {
@@ -95,10 +95,10 @@ public class Servers {
     private Random random = new Random();
 
     /**
-     * Generates a random email address by appending a random string in front of the server's
-     * domain name.
+     * Generates a random email address by appending a random string in front of the
+     * domain name of the inbox (server).
      *
-     * @param serverId The identifier of the server.
+     * @param serverId The identifier of the inbox (server).
      * @return A random email address.
      */
     public String generateEmailAddress(String serverId) {

--- a/src/main/java/com/mailosaur/Usage.java
+++ b/src/main/java/com/mailosaur/Usage.java
@@ -8,6 +8,11 @@ import com.google.api.client.json.GenericJson;
 import com.mailosaur.models.UsageAccountLimits;
 import com.mailosaur.models.UsageTransactionListResult;
 
+/**
+ * Operations for inspecting your account's usage limits and recent transactional usage. These
+ * endpoints require authentication with an account-level API key. Accessed via
+ * {@link MailosaurClient#usage()}.
+ */
 public class Usage {
     private MailosaurClient client;
     

--- a/src/main/java/com/mailosaur/models/Message.java
+++ b/src/main/java/com/mailosaur/models/Message.java
@@ -96,7 +96,7 @@ public class Message extends BaseModel {
     private Metadata metadata;
 
     /**
-     * Identifier for the server in which the message is located.
+     * Identifier for the inbox (server) in which the message is located.
      */
     @Key
     private String server;
@@ -210,9 +210,9 @@ public class Message extends BaseModel {
     }
 
     /**
-     * Gets the identifier for the server in which the message is located.
+     * Gets the identifier for the inbox (server) in which the message is located.
      *
-     * @return Identifier for the server in which the message is located.
+     * @return Identifier for the inbox (server) in which the message is located.
      */
     public String server() {
         return this.server;

--- a/src/main/java/com/mailosaur/models/MessageListParams.java
+++ b/src/main/java/com/mailosaur/models/MessageListParams.java
@@ -7,7 +7,7 @@ import com.google.api.client.util.Key;
  */
 public class MessageListParams {
     /**
-     * The identifier of the server hosting the messages.
+     * The identifier of the inbox (server) hosting the messages.
      */
 	@Key
     private String server;
@@ -37,9 +37,9 @@ public class MessageListParams {
     private String dir;
 
     /**
-     * Gets the identifier of the server hosting the messages.
+     * Gets the identifier of the inbox (server) hosting the messages.
      *
-     * @return The identifier of the server hosting the messages.
+     * @return The identifier of the inbox (server) hosting the messages.
      */
     public String server() {
         return this.server;
@@ -82,9 +82,9 @@ public class MessageListParams {
     }
 
     /**
-     * Sets the identifier of the server hosting the messages.
+     * Sets the identifier of the inbox (server) hosting the messages.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @return the MessageSearchParams object itself.
      */
     public MessageListParams withServer(String server) {

--- a/src/main/java/com/mailosaur/models/MessageSearchParams.java
+++ b/src/main/java/com/mailosaur/models/MessageSearchParams.java
@@ -7,7 +7,7 @@ import com.google.api.client.util.Key;
  */
 public class MessageSearchParams {
     /**
-     * The identifier of the server hosting the messages.
+     * The identifier of the inbox (server) hosting the messages.
      */
 	@Key
     private String server;
@@ -49,9 +49,9 @@ public class MessageSearchParams {
     private String dir;
 
     /**
-     * Gets the identifier of the server hosting the messages.
+     * Gets the identifier of the inbox (server) hosting the messages.
      *
-     * @return The identifier of the server hosting the messages.
+     * @return The identifier of the inbox (server) hosting the messages.
      */
     public String server() {
         return this.server;
@@ -112,9 +112,9 @@ public class MessageSearchParams {
     }
 
     /**
-     * Sets the identifier of the server hosting the messages.
+     * Sets the identifier of the inbox (server) hosting the messages.
      *
-     * @param server The identifier of the server hosting the messages.
+     * @param server The identifier of the inbox (server) hosting the messages.
      * @return the MessageSearchParams object itself.
      */
     public MessageSearchParams withServer(String server) {

--- a/src/main/java/com/mailosaur/models/MessageSummary.java
+++ b/src/main/java/com/mailosaur/models/MessageSummary.java
@@ -70,7 +70,7 @@ public class MessageSummary extends BaseModel {
     private Integer attachments;
 
     /**
-     * Identifier for the server in which the message is located.
+     * Identifier for the inbox (server) in which the message is located.
      */
     @Key
     private String server;
@@ -166,9 +166,9 @@ public class MessageSummary extends BaseModel {
     }
 
     /**
-     * Gets the identifier for the server in which the message is located.
+     * Gets the identifier for the inbox (server) in which the message is located.
      *
-     * @return Identifier for the server in which the message is located.
+     * @return Identifier for the inbox (server) in which the message is located.
      */
     public String server() {
         return this.server;

--- a/src/main/java/com/mailosaur/models/Server.java
+++ b/src/main/java/com/mailosaur/models/Server.java
@@ -4,55 +4,55 @@ import java.util.List;
 import com.google.api.client.util.Key;
 
 /**
- * Mailosaur virtual SMTP/SMS server.
+ * A Mailosaur inbox (server) &mdash; a virtual SMTP/SMS endpoint.
  */
 public class Server {
     /**
-     * Unique identifier for the server.
+     * Unique identifier for the inbox (server).
      */
 	@Key
     private String id;
 
     /**
-     * The name of the server.
+     * The name of the inbox (server).
      */
     @Key
     private String name;
 
     /**
-     * Users (excluding administrators) who have access to the server (if it is restricted).
+     * Users (excluding administrators) who have access to the inbox (server) when access is restricted.
      */
     @Key
     private List<String> users;
 
     /**
-     * The number of messages currently in the server.
+     * The number of messages currently in the inbox (server).
      */
     @Key
     private Integer messages;
 
     /**
-     * Gets the unique identifier of the server.
+     * Gets the unique identifier of the inbox (server).
      *
-     * @return The server ID.
+     * @return The inbox (server) ID.
      */
     public String id() {
         return this.id;
     }
 
     /**
-     * Gets the name of the server.
+     * Gets the name of the inbox (server).
      *
-     * @return The name of the server.
+     * @return The name of the inbox (server).
      */
     public String name() {
         return this.name;
     }
 
     /**
-     * Sets the name of the server.
+     * Sets the name of the inbox (server).
      *
-     * @param name The name of the server.
+     * @param name The name of the inbox (server).
      * @return the Server object itself.
      */
     public Server withName(String name) {
@@ -61,18 +61,18 @@ public class Server {
     }
 
     /**
-     * Gets the IDs of users who have access to the server (if it is restricted).
+     * Gets the IDs of users who have access to the inbox (server) when access is restricted.
      *
-     * @return The IDs of users who have access to the server (if it is restricted).
+     * @return The IDs of users who have access to the inbox (server) when access is restricted.
      */
     public List<String> users() {
         return this.users;
     }
 
     /**
-     * Sets the IDs of users who have access to the server (if it is restricted).
+     * Sets the IDs of users who have access to the inbox (server) when access is restricted.
      *
-     * @param users The IDs of users who have access to the server (if it is restricted).
+     * @param users The IDs of users who have access to the inbox (server) when access is restricted.
      * @return the Server object itself.
      */
     public Server withUsers(List<String> users) {
@@ -81,9 +81,9 @@ public class Server {
     }
 
     /**
-     * Gets the number of messages currently in the server.
+     * Gets the number of messages currently in the inbox (server).
      *
-     * @return The number of messages currently in the server.
+     * @return The number of messages currently in the inbox (server).
      */
     public Integer messages() {
         return this.messages;

--- a/src/main/java/com/mailosaur/models/ServerCreateOptions.java
+++ b/src/main/java/com/mailosaur/models/ServerCreateOptions.java
@@ -3,19 +3,19 @@ package com.mailosaur.models;
 import com.google.api.client.util.Key;
 
 /**
- * Options used to create a new Mailosaur server.
+ * Options used to create a new Mailosaur inbox (server).
  */
 public class ServerCreateOptions {
     /**
-     * A name used to identify the server.
+     * A name used to identify the inbox (server).
      */
     @Key
     private String name;
 
     /**
-     * Sets a name used to identify the server.
+     * Sets a name used to identify the inbox (server).
      *
-     * @param name A name used to identify the server.
+     * @param name A name used to identify the inbox (server).
      * @return the ServerCreateOptions object itself.
      */
     public ServerCreateOptions withName(String name) {

--- a/src/main/java/com/mailosaur/models/ServerListResult.java
+++ b/src/main/java/com/mailosaur/models/ServerListResult.java
@@ -5,21 +5,21 @@ import java.util.List;
 import com.google.api.client.util.Key;
 
 /**
- * The result of the server listing operation.
+ * The result of the inbox (server) listing operation.
  */
 public class ServerListResult {
     /**
-     * The individual servers forming the result. Servers
-     * are returned sorted by creation date, with the most recently-created server
+     * The individual inboxes (servers) forming the result. Inboxes (servers)
+     * are returned sorted by creation date, with the most recently-created inbox (server)
      * appearing first.
      */
     @Key
     private List<Server> items;
 
     /**
-     * Gets the individual servers forming the result.
+     * Gets the individual inboxes (servers) forming the result.
      *
-     * @return The individual servers forming the result.
+     * @return The individual inboxes (servers) forming the result.
      */
     public List<Server> items() {
         return this.items;

--- a/src/main/java/com/mailosaur/models/UsageAccountLimits.java
+++ b/src/main/java/com/mailosaur/models/UsageAccountLimits.java
@@ -7,7 +7,7 @@ import com.google.api.client.util.Key;
  */
 public class UsageAccountLimits {
     /**
-     * Server limits.
+     * Inbox (server) limits.
      */
     @Key
     private UsageAccountLimit servers;
@@ -31,9 +31,9 @@ public class UsageAccountLimits {
     private UsageAccountLimit sms;
 
     /**
-     * Gets server limits.
+     * Gets inbox (server) limits.
      *
-     * @return Server limits.
+     * @return Inbox (server) limits.
      */
     public UsageAccountLimit servers() {
         return this.servers;


### PR DESCRIPTION
## Summary

- Add and expand Intellisense doc comments across the client and operations classes (descriptions, parameters, and return values).
- Adopt **inbox (server)** terminology in the doc-comment prose, so hover documentation matches the dashboard UI.

## Scope

- Doc comments only — no code, public API, or behaviour changes.
- Parameter names, type names, and other code identifiers are unchanged.
